### PR TITLE
Add: WSA support

### DIFF
--- a/module/config/argument/args.json
+++ b/module/config/argument/args.json
@@ -116,7 +116,8 @@
           "aScreenCap_nc",
           "DroidCast",
           "DroidCast_raw",
-          "scrcpy"
+          "scrcpy",
+          "WSA"
         ]
       },
       "ControlMethod": {

--- a/module/config/argument/argument.yaml
+++ b/module/config/argument/argument.yaml
@@ -29,7 +29,7 @@ Emulator:
     option: [ disabled, ]
   ScreenshotMethod:
     value: auto
-    option: [ auto, ADB, ADB_nc, uiautomator2, aScreenCap, aScreenCap_nc, DroidCast, DroidCast_raw, scrcpy ]
+    option: [ auto, ADB, ADB_nc, uiautomator2, aScreenCap, aScreenCap_nc, DroidCast, DroidCast_raw, scrcpy, WSA ]
   ControlMethod:
     value: minitouch
     option: [ ADB, uiautomator2, minitouch, Hermit, MaaTouch ]

--- a/module/config/config_generated.py
+++ b/module/config/config_generated.py
@@ -21,7 +21,7 @@ class GeneratedConfig:
     Emulator_Serial = 'auto'
     Emulator_PackageName = 'auto'  # auto, com.bilibili.azurlane, com.YoStarEN.AzurLane, com.YoStarJP.AzurLane, com.hkmanjuu.azurlane.gp, com.bilibili.blhx.huawei, com.bilibili.blhx.mi, com.tencent.tmgp.bilibili.blhx, com.bilibili.blhx.baidu, com.bilibili.blhx.qihoo, com.bilibili.blhx.nearme.gamecenter, com.bilibili.blhx.vivo, com.bilibili.blhx.mz, com.bilibili.blhx.dl, com.bilibili.blhx.lenovo, com.bilibili.blhx.uc, com.bilibili.blhx.mzw, com.yiwu.blhx.yx15, com.bilibili.blhx.m4399, com.bilibili.blhx.bilibiliMove, com.hkmanjuu.azurlane.gp.mc
     Emulator_ServerName = 'disabled'  # disabled, cn_android-0, cn_android-1, cn_android-2, cn_android-3, cn_android-4, cn_android-5, cn_android-6, cn_android-7, cn_android-8, cn_android-9, cn_android-10, cn_android-11, cn_android-12, cn_android-13, cn_android-14, cn_android-15, cn_android-16, cn_android-17, cn_android-18, cn_android-19, cn_android-20, cn_android-21, cn_android-22, cn_android-23, cn_ios-0, cn_ios-1, cn_ios-2, cn_ios-3, cn_ios-4, cn_ios-5, cn_ios-6, cn_ios-7, cn_ios-8, cn_ios-9, cn_ios-10, cn_channel-0, cn_channel-1, cn_channel-2, cn_channel-3, cn_channel-4, en-0, en-1, en-2, en-3, en-4, en-5, jp-0, jp-1, jp-2, jp-3, jp-4, jp-5, jp-6, jp-7, jp-8, jp-9, jp-10, jp-11, jp-12, jp-13, jp-14, jp-15, jp-16, jp-17
-    Emulator_ScreenshotMethod = 'auto'  # auto, ADB, ADB_nc, uiautomator2, aScreenCap, aScreenCap_nc, DroidCast, DroidCast_raw, scrcpy
+    Emulator_ScreenshotMethod = 'auto'  # auto, ADB, ADB_nc, uiautomator2, aScreenCap, aScreenCap_nc, DroidCast, DroidCast_raw, scrcpy, WSA
     Emulator_ControlMethod = 'minitouch'  # ADB, uiautomator2, minitouch, Hermit, MaaTouch
     Emulator_ScreenshotDedithering = False
     Emulator_AdbRestart = False

--- a/module/config/i18n/en-US.json
+++ b/module/config/i18n/en-US.json
@@ -403,7 +403,8 @@
       "aScreenCap_nc": "aScreenCap_nc",
       "DroidCast": "DroidCast",
       "DroidCast_raw": "DroidCast_raw",
-      "scrcpy": "scrcpy"
+      "scrcpy": "scrcpy",
+      "WSA": "WSA"
     },
     "ControlMethod": {
       "name": "Control Method",

--- a/module/config/i18n/ja-JP.json
+++ b/module/config/i18n/ja-JP.json
@@ -403,7 +403,8 @@
       "aScreenCap_nc": "aScreenCap_nc",
       "DroidCast": "DroidCast",
       "DroidCast_raw": "DroidCast_raw",
-      "scrcpy": "scrcpy"
+      "scrcpy": "scrcpy",
+      "WSA": "WSA"
     },
     "ControlMethod": {
       "name": "Emulator.ControlMethod.name",

--- a/module/config/i18n/zh-CN.json
+++ b/module/config/i18n/zh-CN.json
@@ -403,7 +403,8 @@
       "aScreenCap_nc": "aScreenCap_nc",
       "DroidCast": "DroidCast",
       "DroidCast_raw": "DroidCast_raw",
-      "scrcpy": "scrcpy"
+      "scrcpy": "scrcpy",
+      "WSA": "WSA"
     },
     "ControlMethod": {
       "name": "模拟器控制方案",

--- a/module/config/i18n/zh-TW.json
+++ b/module/config/i18n/zh-TW.json
@@ -403,7 +403,8 @@
       "aScreenCap_nc": "aScreenCap_nc",
       "DroidCast": "DroidCast",
       "DroidCast_raw": "DroidCast_raw",
-      "scrcpy": "scrcpy"
+      "scrcpy": "scrcpy",
+      "WSA": "WSA"
     },
     "ControlMethod": {
       "name": "模擬器控制方案",

--- a/module/device/connection_attr.py
+++ b/module/device/connection_attr.py
@@ -85,11 +85,12 @@ class ConnectionAttr:
             raise RequestHumanTakeover
         if self.is_wsa:
             self.serial = '127.0.0.1:58526'
-            if self.config.Emulator_ScreenshotMethod != 'uiautomator2' \
-                    or self.config.Emulator_ControlMethod != 'uiautomator2':
+            # Emulator_ControlMethod only support ADB currently
+            if self.config.Emulator_ScreenshotMethod != 'WSA' \
+                    or self.config.Emulator_ControlMethod != 'ADB':
                 with self.config.multi_set():
-                    self.config.Emulator_ScreenshotMethod = 'uiautomator2'
-                    self.config.Emulator_ControlMethod = 'uiautomator2'
+                    self.config.Emulator_ScreenshotMethod = 'WSA'
+                    self.config.Emulator_ControlMethod = 'ADB'
         if self.is_over_http:
             if self.config.Emulator_ScreenshotMethod not in ["ADB", "uiautomator2", "aScreenCap"] \
                     or self.config.Emulator_ControlMethod not in ["ADB", "uiautomator2", "minitouch"]:

--- a/module/device/method/winapiutils.py
+++ b/module/device/method/winapiutils.py
@@ -1,0 +1,98 @@
+from ctypes import windll
+import win32gui
+import win32ui
+import win32con
+import cv2
+import numpy as np
+
+from module.exception import GameNotRunningError
+
+from module.device.method.utils import ImageTruncated
+
+
+class Winapiutils:
+    hwnd = None
+    def __init__(self):
+        self.windowposx = 0
+        self.windowposy = 0
+        self.windowwidth = 0
+        self.windowheight = 0
+
+    def find_window(self, winname = None):
+        """
+        Args:
+            winname (str): window name
+
+        """
+        self.hwnd = win32gui.FindWindow(None, winname)
+        if not self.hwnd:
+            raise GameNotRunningError
+
+        self.resize_window()
+
+    def resize_window(self):
+        # ignore the effect of dpi scaling
+        windll.user32.SetProcessDPIAware()
+
+        # get application window information
+        winpos = win32gui.GetWindowRect(self.hwnd)
+        self.windowposx = winpos[0]
+        self.windowposy = winpos[1]
+        self.windowwidth = winpos[2] - winpos[0]
+        self.windowheight = winpos[3] - winpos[1]
+        if (self.windowposx != 0 and self.windowposy != 0) or (self.windowwidth != 1280 and self.windowheight != 720):
+            win32gui.SetWindowLong(self.hwnd, win32con.GWL_STYLE, win32con.WS_SYSMENU)
+            win32gui.SetWindowPos(self.hwnd, None, 0, 0, 1280, 720,
+                                  win32con.SWP_NOSENDCHANGING | win32con.SWP_SHOWWINDOW)
+
+    def get_frame(self):
+        """
+
+        return:
+            image (numpy)
+
+        """
+
+        self.resize_window()
+
+        # return window handle
+        hwndc = win32gui.GetWindowDC(self.hwnd)
+
+        # create device description table
+        mfcdc = win32ui.CreateDCFromHandle(hwndc)
+
+        # create memory device description table
+        savedc = mfcdc.CreateCompatibleDC()
+
+        # create bitmap instance
+        savebitmap = win32ui.CreateBitmap()
+
+        # malloc for bitmap
+        savebitmap.CreateCompatibleBitmap(mfcdc, self.windowwidth, self.windowheight)
+
+        # save screenshot to bitmap
+        savedc.SelectObject(savebitmap)
+
+        # save bitmap to memory
+        windll.user32.PrintWindow(self.hwnd, savedc.GetSafeHdc(), 2)
+
+        # get bitmap information
+        image = savebitmap.GetBitmapBits(True)
+
+        # free memory
+        win32gui.DeleteObject(savebitmap.GetHandle())
+        savedc.DeleteDC()
+        mfcdc.DeleteDC()
+        win32gui.ReleaseDC(self.hwnd, hwndc)
+
+        # process image to numpy array
+        image = np.frombuffer(image, dtype = 'uint8')
+        image.shape = (self.windowheight, self.windowwidth, 4)
+        if image is None:
+            raise ImageTruncated('Empty image after reading from buffer')
+
+        image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
+        if image is None:
+            raise ImageTruncated('Empty image after cv2.cvtColor')
+
+        return image

--- a/module/device/screenshot.py
+++ b/module/device/screenshot.py
@@ -38,6 +38,7 @@ class Screenshot(Adb, WSA, DroidCast, AScreenCap, Scrcpy):
             'DroidCast': self.screenshot_droidcast,
             'DroidCast_raw': self.screenshot_droidcast_raw,
             'scrcpy': self.screenshot_scrcpy,
+            'WSA': self.screenshot_wsa
         }
 
     def screenshot(self):


### PR DESCRIPTION
0.第一次提交PR，不好意思给推到master了，抱歉。

1.通过Windows API抓取游戏截图并转为numpy格式，自动调整游戏窗口为无边框并调整窗口大小为1280x720。可以后台运行。

1.Capture game screenshots through Windows API and convert them to numpy format, automatically adjust the game window to be borderless and adjust the window size to 1280x720. Can run in the background.

2.游戏窗口必须位于屏幕右上角且模拟点击经测试只支持ADB方式，这是因为WSA的点击坐标是以屏幕左上角为坐标原点的（虽然可以通过加offset来解决但好像没必要？）。其它模拟点击方式没有仔细研究过所以没敢动。

2.The game window must be located in the upper right corner of the screen and the simulated click only supports the ADB method after testing. This is because the click coordinates of WSA are based on the upper left corner of the screen as the coordinate origin.

3.demonstration
![demonstration~1](https://github.com/Lyxikun/AzurLaneAutoScript/assets/14973513/f468f2f7-e7e8-460c-a00b-8af50b174828)
